### PR TITLE
Set default for sms_list read_count

### DIFF
--- a/huawei_lte_api/api/Sms.py
+++ b/huawei_lte_api/api/Sms.py
@@ -26,7 +26,7 @@ class Sms(ApiGroup):
     def get_sms_list(self,
                      page: int=1,
                      box_type: BoxTypeEnum=BoxTypeEnum.LOCAL_INBOX,
-                     read_count: int=None,
+                     read_count: int=20,
                      sort_type: int=0,
                      ascending: int=0,
                      unread_preferred: int=0


### PR DESCRIPTION
At least the E5186s-22a seems to require an int >= 1 in it.

Refs https://github.com/Salamek/huawei-lte-api/issues/14