### PR TITLE
Return empty dict instead of None from all API methods

### DIFF
--- a/huawei_lte_api/Connection.py
+++ b/huawei_lte_api/Connection.py
@@ -79,7 +79,8 @@ class Connection:
                 error_code
             )
 
-        return data['response'] if 'response' in data else data
+        response = data['response'] if 'response' in data else data
+        return response if response is not None else {}
 
     def _initialize_csrf_tokens_and_session(self):
         # Reset


### PR DESCRIPTION
More convenient (and already type hinted) for API users that way, and
makes treatment of completely empty responses and <response/>
the same.