### PR TITLE
Omitting xml types to be compatible with B535-232.

### DIFF
--- a/huawei_lte_api/api/Sms.py
+++ b/huawei_lte_api/api/Sms.py
@@ -93,7 +93,7 @@ class Sms(ApiGroup):
         if from_date is None:
             from_date = datetime.datetime.utcnow()
         dicttoxml_xargs = {
-            'item_func': lambda x: x[:-1]
+            'item_func': lambda x: x[:-1],
             'attr_type': False
         }
 

--- a/huawei_lte_api/api/Sms.py
+++ b/huawei_lte_api/api/Sms.py
@@ -94,6 +94,7 @@ class Sms(ApiGroup):
             from_date = datetime.datetime.utcnow()
         dicttoxml_xargs = {
             'item_func': lambda x: x[:-1]
+            'attr_type': False
         }
 
         return self._connection.post('sms/send-sms', OrderedDict((


### PR DESCRIPTION
XML-type declarations makes send_sms fail on the B535-232. 
Fixes #53 
Confirmed working fix.