### PR TITLE
Update supported Python versions, mark >= 3.4 required

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,14 +31,14 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.2',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Software Development',
     ],
+    python_requires='>=3.4',
     setup_requires=[
         'pytest-runner'
     ],


### PR DESCRIPTION
Use of enums without the enum34 dependency means this hasn't worked out
of the box with < 3.4 in a while anyway.