### PR TITLE
Ship huawei_lte_api.usermanual package too

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ setup(
         'huawei_lte_api',
         'huawei_lte_api.api',
         'huawei_lte_api.enums',
-        'huawei_lte_api.config'
+        'huawei_lte_api.config',
+        'huawei_lte_api.usermanual',
     ],
     package_data={'huawei_lte_api': ['py.typed']},
     install_requires=[


### PR DESCRIPTION
1.4.9 is broken due to this:

```
$ python -c "from huawei_lte_api import Client"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".../huawei_lte_api/Client.py", line 33, in <module>
    from huawei_lte_api.usermanual.PublicSysResources import PublicSysResources
ModuleNotFoundError: No module named 'huawei_lte_api.usermanual'
```