### PR TITLE
voice/voicebusy added

### DIFF
--- a/huawei_lte_api/api/Voice.py
+++ b/huawei_lte_api/api/Voice.py
@@ -24,6 +24,9 @@ class Voice(ApiGroup):
     def voiceadvance(self) -> GetResponseType:
         return self._connection.get('voice/voiceadvance')
 
+    def voicebusy(self) -> GetResponseType:
+        return self._connection.get('voice/voicebusy')
+
     def codec(self) -> GetResponseType:
         """
         Endpoint found by reverse engineering B310s-22 firmware, unknown usage, probably not implemented by Huawei

--- a/tests/dump.py
+++ b/tests/dump.py
@@ -299,5 +299,7 @@ dump(client.bluetooth.scan)
 
 dump(client.mlog.mobile_logger)
 
+dump(client.voice.voicebusy)
+
 if isinstance(connection, AuthorizedConnection):
     client.user.logout()


### PR DESCRIPTION
Tested with B525s-23a: when no voice call (i mean voice through rj11, i didn't test with VOIP) is in progress

==== <bound method Voice.voicebusy of <huawei_lte_api.api.Voice.Voice object at 0xb5dd5770>>
'Idle'

when a call is in progress instead

==== <bound method Voice.voicebusy of <huawei_lte_api.api.Voice.Voice object at 0xb5dde7d0>>
'Busy'

