### PR TITLE
彩信无法正常显示，在转换为xml格式时有非法字符，故替换所有非法字符，从而可以让程序完整运行下去

### DIFF
--- a/huawei_lte_api/Connection.py
+++ b/huawei_lte_api/Connection.py
@@ -62,7 +62,9 @@ class Connection:
         # parse as XML (even though it's labeled XHTML). Try to detect
         # such cases, and return a generated "not supported" error
         # instead of letting the XML parse error pass through.
-        xml = response.content
+        xml = response.text
+        #彩信无法正常显示，在转换为xml格式时有非法字符，故替换所有非法字符，从而可以让程序完整运行下去
+        xml=re.sub(u"[\x00-\x08\x0b-\x0c\x0e-\x1f]+",u"",xml)
         try:
             return xmltodict.parse(xml, dict_constructor=dict) if xml else {}
         except:


### PR DESCRIPTION
		<message>
			<smstat>1</smstat>
			<index>40029</index>
			<phone>106550280205</phone>
			<content>:¾´¯dB&#41;qj+</content>
			<date>2020-12-16 15:36:00</date>
			<sca></sca>
			<savetype>0</savetype>
			<priority>0</priority>
			<smstype>5</smstype>
			<unreadcount>0</unreadcount>
		</message>

