### PR TITLE
feat(lan): make sure host_info is always a list

### DIFF
--- a/huawei_lte_api/api/Lan.py
+++ b/huawei_lte_api/api/Lan.py
@@ -4,4 +4,13 @@ from huawei_lte_api.Connection import GetResponseType
 
 class Lan(ApiGroup):
     def host_info(self) -> GetResponseType:
-        return self._connection.get('lan/HostInfo')
+        # Make sure Hosts->Host is a list
+        # It may be returned as a single dict if only one is associated,
+        # as well as sometimes None.
+        hosts = self._connection.get('lan/HostInfo')
+        if hosts.get('Hosts') is None:
+            hosts['Hosts'] = {}
+        host = hosts['Hosts'].setdefault('Host', [])
+        if isinstance(host, dict):
+            hosts['Hosts']['Host'] = [host]
+        return hosts


### PR DESCRIPTION
Similarly as df634440796e281a4cc8e8f1434df70a2e4682c8 and
3fbf7a871b3cd8d522e1adc4e31aaac3185dcb7c fixed WLan.host_list.

Refs https://github.com/Salamek/huawei-lte-api/pull/27
Refs https://github.com/Salamek/huawei-lte-api/pull/52
Refs https://github.com/home-assistant/core/issues/50777