### PR TITLE
README: remove login_on_demand reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ from huawei_lte_api.AuthorizedConnection import AuthorizedConnection
 from huawei_lte_api.Connection import Connection
 
 # connection = Connection('http://192.168.8.1/') For limited access, I have valid credentials no need for limited access
-# connection = AuthorizedConnection('http://admin:MY_SUPER_TRUPER_PASSWORD@192.168.8.1/', login_on_demand=True) # If you wish to login on demand (when call requires authorization), pass login_on_demand=True
 connection = AuthorizedConnection('http://admin:MY_SUPER_TRUPER_PASSWORD@192.168.8.1/')
 
 client = Client(connection) # This just simplifies access to separate API groups, you can use device = Device(connection) if you want


### PR DESCRIPTION
This feature seems to be deprecated according to #67

Since at least 8a893825ed3465e60983fa228ec795732a40bd05 the option doesn't do anything anymore.