### PR TITLE
fix(Connection): close Session even if UserSession close raises

### DIFF
--- a/huawei_lte_api/Connection.py
+++ b/huawei_lte_api/Connection.py
@@ -35,7 +35,11 @@ class Connection(Session):
 
     def close(self) -> None:
         if self.user_session:
-            self.user_session.close()
+            try:
+                self.user_session.close()
+            except:
+                super().close()
+                raise
         super().close()
 
     def __enter__(self) -> 'Connection':


### PR DESCRIPTION
Logout can raise for various reasons, including but not limited to being
unsupported by the device in the first place, and trying while already
being logged out.