### PR TITLE
fix(sms): sending and saving to multiple recipients

### DIFF
--- a/huawei_lte_api/api/Sms.py
+++ b/huawei_lte_api/api/Sms.py
@@ -74,7 +74,7 @@ class Sms(ApiGroup):
 
         return self._session.post_set('sms/save-sms', OrderedDict((
             ('Index', sms_index),
-            ('Phones', OrderedDict([('Phone', phone_number) for phone_number in phone_numbers])),
+            ('Phones', {'Phone': phone_numbers}),
             ('Sca', sca),
             ('Content', message),
             ('Length', len(message)),
@@ -95,7 +95,7 @@ class Sms(ApiGroup):
             from_date = datetime.datetime.utcnow()
         return self._session.post_set('sms/send-sms', OrderedDict((
             ('Index', sms_index),
-            ('Phones', OrderedDict([('Phone', phone_number) for phone_number in phone_numbers])),
+            ('Phones', {'Phone': phone_numbers}),
             ('Sca', sca),
             ('Content', message),
             ('Length', len(message)),


### PR DESCRIPTION
A dict does not work for the phone numbers here, because all the "keys" are named `Phone`. Therefore we ended up sending only to the last recipient in the given list.

Pass a single-key dict and a list for its values so `xmltodict.unparse` serializes it as multiple `Phone` elements which is what we want.

Regression in 1.5, 0b99acd0226de29bc6d549858a27711fc538611d

Refs https://github.com/home-assistant/core/issues/72899

Note: I've only tinkered with `send_sms`, but `save_sms` seems the same.