### PR TITLE
feat: support some JSON array endpoints

### DIFF
--- a/examples/data_dump.py
+++ b/examples/data_dump.py
@@ -323,6 +323,8 @@ with Connection(args.url, username=args.username, password=args.password) as con
     dump(client.system.devcapacity)
     dump(client.system.deviceinfo)
     dump(client.system.deviceinfoex)
+    dump(client.system.hostinfo)
+    dump(client.system.onlinestate)
     dump(client.system.onlineupg)
 
     dump(client.app.operatorinfo)

--- a/huawei_lte_api/Session.py
+++ b/huawei_lte_api/Session.py
@@ -108,7 +108,7 @@ class Session:
             # Others are not conclusive, e.g. text/html may have JSON or XML
 
         # Resort to content sniffing if Content-Type wasn't conclusive
-        if is_json is None and data and data.startswith(b'{'):
+        if is_json is None and data and data[0:1] in (b'{', b'['):
             is_json = True
 
         if is_json:

--- a/huawei_lte_api/api/System.py
+++ b/huawei_lte_api/api/System.py
@@ -1,3 +1,5 @@
+from typing import List, cast
+
 from huawei_lte_api.ApiGroup import ApiGroup
 from huawei_lte_api.Session import GetResponseType
 
@@ -17,4 +19,16 @@ class System(ApiGroup):
             'system/onlineupg',
             data={'action': 'check', 'data': {'UpdateAction': 1}},
             is_json=True,
+        )
+
+    def onlinestate(self, devid: str = 'all') -> List[GetResponseType]:
+        return cast(
+            List[GetResponseType],
+            self._session.get('system/onlinestate', {'devid': devid})
+        )
+
+    def hostinfo(self) -> List[GetResponseType]:
+        return cast(
+            List[GetResponseType],
+            self._session.get('system/HostInfo')
         )


### PR DESCRIPTION
Some endpoints return JSON arrays instead of objects. This adds support for two such ones, and related sniffing where proper Content-Type isn't available.

The casts here are not nice at all, but going all the way with fixing the type hints to accommodate this would result in the need to add _lots_ of them all over the codebase. And because some of the lower level return type hints are incorrect already, adding these bits doesn't seem that gross.

(No need for a release for this either yet, as far as I'm concerned, I have still some other bits pending.)