### PR TITLE
Suppress login required and not supported on UserSession close

### DIFF
--- a/huawei_lte_api/api/User.py
+++ b/huawei_lte_api/api/User.py
@@ -16,6 +16,7 @@ from huawei_lte_api.exceptions import ResponseErrorException, \
     LoginErrorUsernamePasswordWrongException, \
     LoginErrorUsernameWrongException, \
     LoginErrorPasswordWrongException, \
+    ResponseErrorLoginRequiredException, \
     ResponseErrorNotSupportedException
 
 DEFAULT_USERNAME = 'admin'
@@ -27,7 +28,11 @@ class UserSession:
         self.user.login(username, password, True)
 
     def close(self) -> None:
-        self.user.logout()
+        try:
+            self.user.logout()
+        except (ResponseErrorLoginRequiredException, ResponseErrorNotSupportedException):
+            # Idempotency/nothing further to do, suppress
+            pass
 
     def __enter__(self) -> 'UserSession':
         return self


### PR DESCRIPTION
Treat login required to mean we're already logged out, and if logout is not supported, there's nothing further that can be done about it as far as closing a session goes.