### PR TITLE
Support b28 in net_mode.py example command

### DIFF
--- a/examples/net_mode.py
+++ b/examples/net_mode.py
@@ -32,6 +32,7 @@ BANDS = {
     '7': LTEBandEnum.B7,
     '8': LTEBandEnum.B8,
     '20': LTEBandEnum.B20,
+    '28': LTEBandEnum.B28,
     '38': LTEBandEnum.B38,
     '40': LTEBandEnum.B40,
 }

--- a/huawei_lte_api/enums/net.py
+++ b/huawei_lte_api/enums/net.py
@@ -51,6 +51,7 @@ class LTEBandEnum(enum.IntEnum):
     B7 = 0x40
     B8 = 0x80
     B20 = 0x80000
+    B28 = 0x8000000
     B38 = 0x2000000000
     B40 = 0x8000000000
     ALL = 0x7fffffffffffffff


### PR DESCRIPTION
Minor change, but the net_mode.py command in the examples folder is a pretty good utility to change the band lock mode as-is. Therefor it is nice to add b28, which is supported by the e3372-325 stick, and most CPEs