### PR TITLE
fixed `set_multi_macfilter_settings` documentation + added an example

### DIFF
--- a/examples/mac_filter.py
+++ b/examples/mac_filter.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+"""
+Example code To add a Mac address to your blocklist, you can try it by running:
+python3 mac_filter.py http://192.168.8.1/ --username admin --password PASSWORD --mac 66:77:88:99:AA:BB --hostname fake_mac_adr --index 0 --status 2
+"""
+
+from argparse import ArgumentParser
+from huawei_lte_api.Connection import Connection
+from huawei_lte_api.api.WLan import WLan
+
+
+parser = ArgumentParser()
+parser.add_argument('url', type=str)
+parser.add_argument('--username', type=str)
+parser.add_argument('--password', type=str)
+parser.add_argument('--mac', type=str)
+parser.add_argument('--hostname', type=str)
+parser.add_argument('--index', type=str)
+parser.add_argument('--status', type=str)
+args = parser.parse_args()
+args = parser.parse_args()
+
+with Connection(args.url, username=args.username, password=args.password) as connection:
+    wlan = WLan(connection)
+    clients = [{'WifiMacFilterMac0': args.mac,
+                'wifihostname0': args.hostname, 'Index': args.index, 'WifiMacFilterStatus': args.status}]
+    response = wlan.set_multi_macfilter_settings(clients)

--- a/huawei_lte_api/api/WLan.py
+++ b/huawei_lte_api/api/WLan.py
@@ -140,8 +140,7 @@ class WLan(ApiGroup):
 
     def set_multi_macfilter_settings(self, clients: list) -> SetResponseType:
         """
-
-        :param clients: list of dicts with format {'wifihostname': hostname,'WifiMacFilterMac': mac}
+        :param clients: list of dicts with format {'WifiMacFilterMac0': 'mac address','wifihostname0': 'name', 'Index': 'number', 'WifiMacFilterStatus': 'number(1 or 2)'}
         """
         return self._session.post_set('wlan/multi-macfilter-settings', {
             'Ssids': {


### PR DESCRIPTION
i fixed the documentation based on the payload i found in the dev tools
```xml
<?xml version="1.0" encoding="UTF-8"?>
<request>
    <Ssids>
        <Ssid>
            <WifiMacFilterMac0>66:77:88:99:AA:BB</WifiMacFilterMac0>
            <wifihostname0>66:77:88:99:AA:BB</wifihostname0>
            <Index>0</Index>
            <WifiMacFilterStatus>2</WifiMacFilterStatus>
        </Ssid>
    </Ssids>
</request>
```

What i know for now is `<WifiMacFilterStatus>2</WifiMacFilterStatus>`  add to the block list , no idea how to add to the whitelist
also if you `SET` another mac adr in the same `index` it will replace it