### PR TITLE
Update dialup profile

### DIFF
--- a/huawei_lte_api/api/DialUp.py
+++ b/huawei_lte_api/api/DialUp.py
@@ -59,10 +59,11 @@ class DialUp(ApiGroup):
                        apn: Optional[str] = None,
                        dialup_number: Optional[str] = None,
                        auth_mode: AuthModeEnum = AuthModeEnum.AUTO,
-                       ip_type: IpType = IpType.IPV4_IPV6
+                       ip_type: IpType = IpType.IPV4_IPV6,
+                       is_default: bool = False
                        ) -> SetResponseType:
         return self._session.post_set('dialup/profiles', {
-            'SetDefault': 0,
+            'SetDefault': 1 if is_default else 0, # For E5576, the new profile will always become the default (See #221)
             'Delete': 0,
             'Modify': 1,
             'Profile': {

--- a/huawei_lte_api/api/DialUp.py
+++ b/huawei_lte_api/api/DialUp.py
@@ -38,9 +38,9 @@ class DialUp(ApiGroup):
             'dataswitch': dataswitch
         })
 
-    def set_default_profile(self, default: int = 0) -> SetResponseType:
+    def set_default_profile(self, index: int = 0) -> SetResponseType:
         return self._session.post_set('dialup/profiles', {
-            'SetDefault': default,
+            'SetDefault': index,
             'Delete': 0,
             'Modify': 0
         }, is_encrypted=True)
@@ -59,15 +59,49 @@ class DialUp(ApiGroup):
                        apn: Optional[str] = None,
                        dialup_number: Optional[str] = None,
                        auth_mode: AuthModeEnum = AuthModeEnum.AUTO,
-                       ip_type: IpType = IpType.IPV4_IPV6,
-                       is_default: bool = False
+                       ip_type: IpType = IpType.IPV4_IPV6
                        ) -> SetResponseType:
         return self._session.post_set('dialup/profiles', {
-            'SetDefault': 1 if is_default else 0,
+            'SetDefault': 0,
             'Delete': 0,
             'Modify': 1,
             'Profile': {
                 'Index': '',
+                'IsValid': 1,
+                'Name': name,
+                'ApnIsStatic': 1 if apn else 0,
+                'ApnName': apn,
+                'DialupNum': dialup_number,
+                'Username': username,
+                'Password': password,
+                'AuthMode': auth_mode.value,
+                'IpIsStatic': '',
+                'IpAddress': '',
+                'DnsIsStatic': '',
+                'PrimaryDns': '',
+                'SecondaryDns': '',
+                'ReadOnly': '0',
+                'iptype': ip_type.value
+            }
+        }, is_encrypted=True)
+
+    def update_profile(self,
+                       index: int,
+                       name: str,
+                       username: Optional[str] = None,
+                       password: Optional[str] = None,
+                       apn: Optional[str] = None,
+                       dialup_number: Optional[str] = None,
+                       auth_mode: AuthModeEnum = AuthModeEnum.AUTO,
+                       ip_type: IpType = IpType.IPV4_IPV6,
+                       is_default: bool = False
+                       ) -> SetResponseType:
+        return self._session.post_set('dialup/profiles', {
+            'SetDefault': index if is_default else 0,
+            'Delete': 0,
+            'Modify': 2,
+            'Profile': {
+                'Index': index,
                 'IsValid': 1,
                 'Name': name,
                 'ApnIsStatic': 1 if apn else 0,


### PR DESCRIPTION
While working on the api for dialup profiles, I noticed a few things:
* it looks like you can't really control the behaviour of SetDefault when creating a profile. It looks like newly created profiles always become the default, irregardless of the `SetDefault` parameter value. I removed the parameter from the function.
* When creating a profile without dialup_number (`DialupNum`), the request failed with error `100001`. It looks to me that this field is not optional in my setup... I didn't change this in the code as the example script doesn't have this param so I guess it might work in some cases without dialup_number. 
* FYI, I couldn't remove the default profile, which has the `ReadOnly` set to `2` (instead of `0` for manually created profiles)

I tested these things against the api of the Huawei E5576-320, so it might be different on other devices.