### PR TITLE
Fix: Unlock PIN method returning 101006 Unknown Error

### DIFF
--- a/huawei_lte_api/api/Pin.py
+++ b/huawei_lte_api/api/Pin.py
@@ -14,8 +14,8 @@ class Pin(ApiGroup):
     def save_pin(self) -> GetResponseType:
         return self._session.get('pin/save-pin')
 
-    def operate(self, operate_type: int = 0, current_pin: Optional[int] = None,
-                new_pin: Optional[int] = None, puk_code: Optional[int] = None) \
+    def operate(self, operate_type: str = "0", current_pin: Optional[str] = None,
+                new_pin: Optional[str] = None, puk_code: Optional[str] = None) \
             -> SetResponseType:
         """
         Parameters
@@ -39,4 +39,4 @@ class Pin(ApiGroup):
             'CurrentPin': current_pin,
             'NewPin': new_pin,
             'PukCode': puk_code
-        })
+        }, is_encrypted=True)


### PR DESCRIPTION
## What was wrong:

The unlock_pin method was returning the error code 101006 Unknown Error and failing to unlock the PIN on certain modem models, including the E3372.


## What you did to fix it:

The cause of this issue was identified as incorrectly typing the data provided to the /pin/operate endpoint. Additionally, The request was not encrypting the data sent.


## Any additional testing or considerations:

I tested the fix on one modem model, The E3372.


This fix should resolve the issues detailed in [Issue #223](https://github.com/Salamek/huawei-lte-api/issues/223). Please review the changes and let me know if further adjustments are needed.