### PR TITLE
reconnect api

### DIFF
--- a/huawei_lte_api/api/Net.py
+++ b/huawei_lte_api/api/Net.py
@@ -81,3 +81,8 @@ class Net(ApiGroup):
 
     def csps_state(self) -> GetResponseType:
         return self._session.get('net/csps_state')
+
+    def reconnect(self) -> GetResponseType:
+        return self._session.post_set('net/reconnect', OrderedDict((
+            ('ReconnectAction', 1),
+        )))

--- a/huawei_lte_api/api/Net.py
+++ b/huawei_lte_api/api/Net.py
@@ -82,7 +82,7 @@ class Net(ApiGroup):
     def csps_state(self) -> GetResponseType:
         return self._session.get('net/csps_state')
 
-    def reconnect(self) -> GetResponseType:
+    def reconnect(self) -> SetResponseType:
         return self._session.post_set('net/reconnect', OrderedDict((
             ('ReconnectAction', 1),
         )))


### PR DESCRIPTION
On B818-263, there's a reconnect API endpoint. "ReconnectAction" seems to only accept 1 as value.
This will reconnect the modem if it's disconnected, but seems to not do anything on already established connection.

I found it useful to monitor WAN IP and call reconnect any time the connection drops (my B818-263 seems to drop it every day or so, and without scripting it takes ~15min to reconnect by itself).