### PR TITLE
fix: timerule endpoint

### DIFF
--- a/huawei_lte_api/api/TimeRule.py
+++ b/huawei_lte_api/api/TimeRule.py
@@ -5,4 +5,4 @@ from huawei_lte_api.Session import GetResponseType
 class TimeRule(ApiGroup):
 
     def timerule(self) -> GetResponseType:
-        return self._session.get('time/timerule')
+        return self._session.get('timerule/timerule')


### PR DESCRIPTION
It's not certain that a `time/timerule` endpoint would not exist, but at least `timerule/timerule` does, and because this was placed in `api/TimeRule.py` it suggests this may have been a typo.