### PR TITLE
chore: run CI on Ubuntu 22

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12.0-alpha - 3.12"]


### PR DESCRIPTION
Ubuntu 20 is no longer supported,
https://github.com/actions/runner-images/issues/11101