### PR TITLE
chore(ci): run linters only with latest Python

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -21,9 +21,12 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[dev,test]
-    - name: Test
+    - name: Lint
+      if: ${{ matrix.python-version == '3.14' }}
       run: |
         ruff check .
         ruff format --check .
-        mypy . --python-version ${{ matrix.python-version }}
+        mypy .
+    - name: Test
+      run: |
         pytest .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,12 @@ disallow_subclassing_any = false
 disallow_untyped_decorators = false
 exclude = "(.venv/.*|build/.*)"
 
+[[tool.mypy.overrides]]
+module = ["_pytest.*"]
+# With new Python versions, we may receive a pytest that won't typecheck
+# (done along with tests) with mypy python_version set to our lowest bound
+follow_imports = "skip"
+
 
 [tool.pytest.ini_options]
 # Tell pytest where to look for tests


### PR DESCRIPTION
The configs of ruff and mypy specify the lowest common Python version. Running ruff with later versions is redundant, and running mypy with overriding target python version to each supported may yield findings on later that are not valid for earlier supported versions.