### PR TITLE
chore(ruff): remove target-version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ exclude = ["tests*", "examples*"]
 
 [tool.ruff]
 line-length = 170
-target-version = "py39"
 
 [tool.ruff.lint]
 select = ["ALL"]


### PR DESCRIPTION
Ruff takes it from project.requires-python.

https://docs.astral.sh/ruff/settings/#target-version